### PR TITLE
Update LedBargraph.java

### DIFF
--- a/src/main/java/eu.hansolo.enzo/ledbargraph/LedBargraph.java
+++ b/src/main/java/eu.hansolo.enzo/ledbargraph/LedBargraph.java
@@ -65,6 +65,8 @@ public class LedBargraph extends Control {
         getStyleClass().add("bargraph");
         ledColors = new SimpleListProperty(this, "ledColors", FXCollections.<Color>observableArrayList());
         value     = new SimpleDoubleProperty(this, "value", 0);
+        noOfLeds = new SimpleIntegerProperty(this, "noOfLeds", _noOfLeds);
+        ledSize = new SimpleDoubleProperty(this, "ledSize", _ledSize);
 
         for (int i = 0 ; i < getNoOfLeds() ; i++) {
             if (i < 11) {


### PR DESCRIPTION
NullPointerException at eu.hansolo.enzo.ledbargraph.LedBargraph.setNoOfLeds(LedBargraph.java:159).
The SimpleIntegerProperty noOfLeds isn't initialized (ledSize too). Try:
LedBargraphBuilder.create()
                                    .ledType(Led.LedType.SQUARE)
                                    .orientation(Orientation.VERTICAL)
                                    .peakValueVisible(true)
                                    .ledSize(32)
                                    .noOfLeds(10)
                                    .build();